### PR TITLE
Fix for ä ö ü Ä Ö Ü ß symbols.

### DIFF
--- a/library/Zend/Mail/Header/HeaderValue.php
+++ b/library/Zend/Mail/Header/HeaderValue.php
@@ -92,7 +92,7 @@ final class Zend_Mail_Header_HeaderValue
         $tot = strlen($value);
         for ($i = 0; $i < $tot; $i += 1) {
             $ord = ord($value[$i]);
-            if (($ord < 32 || $ord > 126)
+            if (($ord < 32 || $ord > 255)
                 && $ord !== 13
             ) {
                 return false;


### PR DESCRIPTION
Zend Framework 1 reaches its End of Life (EOL) and is no longer maintained.
No Pull Requests will be accepted.

https://framework.zend.com/blog/2016-06-28-zf1-eol.html
